### PR TITLE
Bump version number

### DIFF
--- a/term/build.js
+++ b/term/build.js
@@ -314,6 +314,10 @@ exports.build_resources = async (browser) => {
 
     const process_one = async (name, db_entry, record_stream) => {
         const re_extract_mime = /^[^/]+\/([^\s;]+)/;
+        const safe_exts = {
+            "javascript": "js",
+            "plain": "txt",
+        }
 
         record_stream.write(name);
         record_stream.write("\n");
@@ -331,6 +335,9 @@ exports.build_resources = async (browser) => {
         // around a Mac OS operating system bug)
         const suffix = re_extract_mime.exec(db_entry.mime);
         assert(suffix !== null);
+        if (suffix[1] in safe_exts) {
+            suffix[1] = safe_exts[suffix[1]];
+        }
         name = "\t" + name + "." + suffix[1];
 
         record_stream.write(name);

--- a/term/data.js
+++ b/term/data.js
@@ -38,7 +38,7 @@ const assert = require("assert");
  * Version number.
  * @const {string}
  */
-exports.version = "1.0.0.92";
+exports.version = "1.0.0.93";
 
 /**
  * The based on string.


### PR DESCRIPTION
The commit fixed a problem that redirect not working on Nano Adblocker Firefox (Maybe this is the reason why uBO map `.javascript` to `.js` and so on?). Possibly some quick reports from Firefox unable to reproduce on your side may be due to this reason.

Not sure if it affect Chromium too (I guess no). If not, feel free to close it. Just to notice sync up version number when bumping to uBO1.18.6. Thanks and sorry for inconvenience just because my fault. 