### PR TITLE
fix(assets): update urlhaus-filter URL

### DIFF
--- a/src/assets.json
+++ b/src/assets.json
@@ -211,7 +211,8 @@
     "group": "malware",
     "title": "Online Malicious URL Blocklist",
     "contentURL": [
-      "https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt",
+      "https://curben.gitlab.io/malware-filter/urlhaus-filter-online.txt",
+      "https://raw.githubusercontent.com/curbengh/urlhaus-filter/master/urlhaus-filter-online.txt",
       "assets/ThirdParty/MalwareDomain2.txt"
     ],
     "cdnURLs": [
@@ -219,7 +220,7 @@
       "https://gitcdn.xyz/repo/curbengh/urlhaus-filter/master/urlhaus-filter-online.txt",
       "https://cdn.jsdelivr.net/gh/curbengh/urlhaus-filter/urlhaus-filter-online.txt",
       "https://raw.githubusercontent.com/curbengh/urlhaus-filter/master/urlhaus-filter-online.txt",
-      "https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt"
+      "https://curben.gitlab.io/malware-filter/urlhaus-filter-online.txt"
     ],
     "supportURL": "https://gitlab.com/curben/urlhaus-filter#urlhaus-malicious-url-blocklist"
   },


### PR DESCRIPTION
- https://github.com/uBlockOrigin/uBlock-issues/issues/1285

urlhaus-filter (Online Malicious URL Blocklist) has recently hit the GitLab raw repo link limit. Taking a page from [VSCodium](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/-/issues/36), I've set up another mirror on GitLab Pages.

Ref:
- https://github.com/gorhill/uBlock/commit/3693755e940cbd5e12b1d7783342756aff09539a
- https://www.reddit.com/r/uBlockOrigin/comments/j1ehm5/
- https://gitlab.com/curben/urlhaus-filter/-/issues/26